### PR TITLE
Math/Decimal Void-safe

### DIFF
--- a/example/math/decimal/telco/telco.e
+++ b/example/math/decimal/telco/telco.e
@@ -41,6 +41,7 @@ feature {NONE} -- Initialization
 	make
 			-- Start telco benchmark.
 		do
+			create last_number.make_zero
 			std.output.put_line ("-- telco application")
 			std.output.put_line ("--")
 			std.output.put_line ("-- Benchmark for Decimal Arithmetic")
@@ -267,6 +268,7 @@ feature -- Basic operations
 			a_file_not_end_of_input: not a_file.end_of_input
 		local
 			l_packed_string: STRING
+			l_last_decimal : detachable MA_DECIMAL
 		do
 			a_file.read_string (8)
 			if not a_file.end_of_input then
@@ -274,7 +276,9 @@ feature -- Basic operations
 					l_packed_string := a_file.last_string
 					bcd_parser.parse (l_packed_string)
 					if not bcd_parser.error then
-						last_number := bcd_parser.last_decimal
+						l_last_decimal := bcd_parser.last_decimal
+						check l_last_decimal /= Void end
+						last_number := l_last_decimal
 					else
 						Exceptions.raise ("Invalid file format: need 8 byte packed decimal")
 					end

--- a/library/math/decimal/ma_decimal.e
+++ b/library/math/decimal/ma_decimal.e
@@ -236,6 +236,8 @@ feature {NONE} -- Initialization
 		require
 			a_decimal_parser_not_void: a_decimal_parser /= Void
 			a_context_not_void: a_context /= Void
+		local
+			l_last_parsed: detachable STRING
 		do
 			if a_decimal_parser.error then
 				if a_context.is_extended then
@@ -272,7 +274,9 @@ feature {NONE} -- Initialization
 						exponent := exponent - a_decimal_parser.fractional_part_count
 					end
 					create {MA_DECIMAL_COEFFICIENT_IMP} coefficient.make ((a_context.digits + 1).max (a_decimal_parser.coefficient_count))
-					coefficient.set_from_substring (a_decimal_parser.last_parsed, a_decimal_parser.coefficient_begin, a_decimal_parser.coefficient_end)
+					l_last_parsed := a_decimal_parser.last_parsed
+					check l_last_parsed /= Void end
+					coefficient.set_from_substring (l_last_parsed, a_decimal_parser.coefficient_begin, a_decimal_parser.coefficient_end)
 					clean_up (a_context)
 				end
 			end
@@ -681,6 +685,7 @@ feature -- Basic operations
 			-- Current decimal to the power `other'
 		do
 				--| TODO
+				Result := nan
 		end
 
 	is_less alias "<" (other: like Current): BOOLEAN
@@ -949,6 +954,8 @@ feature -- Basic operations
 							Result := negative_infinity
 						end
 					end
+				else
+					Result := nan
 				end
 			else
 				if is_zero or else other.is_zero then
@@ -1021,6 +1028,8 @@ feature -- Basic operations
 					if is_negative then
 						Result.set_negative
 					end
+				else
+					Result := nan
 				end
 			else
 				if other.is_zero then
@@ -1400,6 +1409,8 @@ feature -- Basic operations
 							-- compare (x, +inf) : x < Inf
 						Result := minus_one
 					end
+				else
+					Result := nan
 				end
 			else
 				create operand_a.make_copy (Current)
@@ -1535,6 +1546,8 @@ feature {MA_DECIMAL} -- Basic operations
 						Result := infinity
 					end
 				end
+			else
+				Result := nan
 			end
 		ensure
 			add_special_not_void: Result /= Void
@@ -1582,6 +1595,8 @@ feature {MA_DECIMAL} -- Basic operations
 						Result := infinity
 					end
 				end
+			else
+				Result := nan
 			end
 		ensure
 			subtract_special_not_void: Result /= Void
@@ -2202,6 +2217,7 @@ feature {MA_DECIMAL} -- Basic operations
 		local
 			e_tiny, shared_digits, subnormal_count, count_upto_elimit, saved_digits: INTEGER
 			l_is_zero, l_was_rounded: BOOLEAN
+			l_reason : detachable STRING
 			value: INTEGER
 		do
 			l_is_zero := is_zero
@@ -2272,7 +2288,9 @@ feature {MA_DECIMAL} -- Basic operations
 				exponent := e_tiny
 				if l_is_zero then
 					if l_was_rounded then
-						ctx.signal (Signal_rounded, ctx.reason)
+						l_reason := ctx.reason
+						check l_reason /= Void end
+						ctx.signal (Signal_rounded, l_reason)
 					else
 						ctx.reset_flag (Signal_rounded)
 					end
@@ -2321,6 +2339,8 @@ feature {MA_DECIMAL} -- Basic operations
 					else
 						Result := negative_zero
 					end
+				else
+					Result := nan
 				end
 			else
 				if other.is_zero then

--- a/library/math/decimal/ma_decimal_bcd_parser.e
+++ b/library/math/decimal/ma_decimal_bcd_parser.e
@@ -40,10 +40,11 @@ feature -- Basic operations
 			l_coefficient: MA_DECIMAL_COEFFICIENT
 			nibble_index, c_code: INTEGER
 			c: CHARACTER
+			l_last_decimal : MA_DECIMAL
 		do
 			error := False
-			create last_decimal.make (packed_string.count * 2 - 1)
-			l_coefficient := last_decimal.coefficient
+			create l_last_decimal.make (packed_string.count * 2 - 1)
+			l_coefficient := l_last_decimal.coefficient
 			zero_code := ('0').code
 			from
 				index := 1
@@ -66,17 +67,21 @@ feature -- Basic operations
 				else
 					inspect lo
 					when 11, 13 then
-						last_decimal.set_negative
+						l_last_decimal.set_negative
 					when 10, 12, 14, 15 then
 							-- Do nothing.
 					else
 --						create e
 --						e.raise ("Invalid file format : need 8 bytes packed decimal")
 						error := True
-						last_decimal := Void
 					end
 				end
 				index := index + 1
+			end
+			if error then
+				last_decimal := Void
+			else
+				last_decimal := l_last_decimal
 			end
 		end
 

--- a/library/math/decimal/ma_decimal_context.e
+++ b/library/math/decimal/ma_decimal_context.e
@@ -159,7 +159,7 @@ feature -- Access
 			-- Rounding algorithm to be used for an operation when non-zero digits have to
 			-- be discarded in order to reduce the precision of a result
 
-	reason: STRING
+	reason: detachable STRING
 			-- Reason of latest raised signal
 
 	exponent_limit: INTEGER

--- a/library/math/decimal/ma_decimal_parser.e
+++ b/library/math/decimal/ma_decimal_parser.e
@@ -21,7 +21,7 @@ feature {NONE} -- Initialization
 
 feature -- Access
 
-	last_decimal: MA_DECIMAL
+	last_decimal: detachable MA_DECIMAL
 			-- Last decimal parsed
 
 feature -- Status report

--- a/library/math/decimal/ma_decimal_text_parser.e
+++ b/library/math/decimal/ma_decimal_text_parser.e
@@ -94,7 +94,7 @@ feature -- Access
 	decimal_point_index: INTEGER
 			-- Index of decimal point if any
 
-	last_parsed: STRING
+	last_parsed: detachable STRING
 			-- Last parsed string
 
 feature -- Status report


### PR DESCRIPTION
Hello Eric,

Here is a pull request for commit https://github.com/pgcrism/gobo/commit/83ebaede949ca3322ed1e6d11dc64a625a3ef70b .

Math/Decimal is now void-safe if my tests are OK.

Do you need any xace or ecf file to test for it?
Best regards,

Paul G. Crismer
