### PR TITLE
Fix GCC linker options order

### DIFF
--- a/tool/gec/config/c/gcc.cfg
+++ b/tool/gec/config/c/gcc.cfg
@@ -1,6 +1,6 @@
 -- Command lines
 cc: gcc $cflags $includes  $gc_includes -c $c
-link: gcc $lflags -lm -o $exe $objs $libs $gc_libs
+link: gcc $lflags -o $exe $objs -lm $libs $gc_libs
 
 -- File extensions
 obj: .o


### PR DESCRIPTION
GCC 4.6 has become fussier about the order of its options.
The -l options must now appear after the object files.

Without this patch, I have a GGC error when compiling a
custom project with gec:

 epm1.o: In function `T163f16':
 epm1.c:(.text+0xa9f): undefined reference to`pow'
 epm1.c:(.text+0xad4): undefined reference to `pow'

Tested on Ubuntu 12.04 LTS with GCC 4.6.3.

Links :
- http://nick.zoic.org/art/etc/gcc-linker-libs.html
- http://ubuntuforums.org/showthread.php?p=11339484
