### PR TITLE
Emit Makefile instead of script

### DIFF
--- a/tool/gec/config/c/cc.cfg
+++ b/tool/gec/config/c/cc.cfg
@@ -1,6 +1,6 @@
 -- Command lines
-cc: cc $cflags $includes -c $c
-link: cc $lflags $lflags_threads -lm -o $exe $objs $libs
+cc: cc $cflags $includes $gc_includes -c $c
+link: cc $lflags -o $exe $objs $lflags_threads -lm $gc_libs $libs
 
 -- File extensions
 obj: .o
@@ -13,6 +13,12 @@ lflags:
 #else
 cflags: -fast
 lflags:
+#endif
+gc_includes:
+#ifdef GE_USE_BOEHM_GC
+gc_libs: -lgc
+#else
+gc_libs:
 #endif
 #ifdef GE_USE_THREADS
 lflags_threads: -pthread

--- a/tool/gec/config/c/gcc.cfg
+++ b/tool/gec/config/c/gcc.cfg
@@ -1,5 +1,5 @@
 -- Command lines
-cc: gcc $cflags $includes  $gc_includes -c $c
+cc: gcc $cflags $includes $gc_includes -c $c
 link: gcc $lflags -o $exe $objs $lflags_threads -lm $gc_libs $libs
 
 -- File extensions
@@ -17,7 +17,7 @@ lflags:
 #endif
 #ifdef GE_USE_BOEHM_GC
 gc_includes: -I$BOEHM_GC/include -I$BOEHM_GC/include/gc
-gc_libs: $BOEHM_GC/lib/libgc.a
+gc_libs: -lgc
 #else
 gc_includes:
 gc_libs:


### PR DESCRIPTION
This patch changes `gec` to emit a Makefile instead of a script to compile generated C code.

This accomplishes two things:

1. `make` is able to use parallel builds, greatly speeding up gec compilation. I.e. can now use every core.
2. `gec` used to need to know what compiler it should be using, but on every modern platform that is solved. That knowledge can be removed potentially.

The generated Makefile is such that it can be dropped as-is into Debian (and derivatives) and FreeBSD package builds: simply rename it to `Makefile`. It is now trivial to take Eiffel code, compile it on one platform, and use the generated C code + Makefile to target every modern Unix platform.

I also changed the behaviour to link against the Boehm library, every platform now has `libgc.so`, but not always `libgc.a` (termux on Android). I think we can drop the include flags as well.

I still generate the .sh script, but technically that's not needed anymore, could immediately call make. Requires some minor changes in `gec.e`.

Here is the generated makefile for `gec` itself, i.e. `gec.make`:

````
#
# Makefile generated by gec.
#

.PHONY: all install clean distclean uninstall

all: gec

prefix = /usr/local
exec_prefix = $(prefix)
bindir = $(exec_prefix)/bin
mandir = $(prefix)/man
man1dir = $(mandir)/man1

INSTALL = install -C
INSTALL_PROGRAM = $(INSTALL)
INSTALL_DATA = $(INSTALL)

CFLAGS +=   -I$BOEHM_GC/include -I$BOEHM_GC/include/gc
LDFLAGS +=  
LDLIBS += -lm -lgc -lpthread
OBJS = gec8.o gec7.o gec6.o gec5.o gec4.o gec3.o gec2.o gec1.o

gec: $(OBJS) gec.h
	$(CC) $(CFLAGS) $(LDFLAGS) -o gec $(OBJS) $(LDLIBS)

clean:
	-rm $(OBJS) gec

distclean: clean

install:
	$(INSTALL_PROGRAM) -d $(DESTDIR)$(bindir)
	$(INSTALL_PROGRAM) gec $(DESTDIR)$(bindir)

uninstall:
	-rm -f $(DESTDIR)$(bindir)/gec

.c.o:
	$(CC) $(CFLAGS) -c $<
````

And the `gec.sh` file:

````
#!/bin/sh
make -f gec.make
````
