### PR TITLE
Path "/" was parsed wrongly, UT_URI.path was "//" in that case

### DIFF
--- a/library/utility/src/uri/ut_uri.e
+++ b/library/utility/src/uri/ut_uri.e
@@ -911,7 +911,9 @@ feature {NONE} -- URI parsing
 				-- Handle last part of string.
 			inspect state
 			when State_scheme, State_authority_prefix, State_path then
-				stop_path_base (start, i)
+				if state /= State_authority_prefix then
+					stop_path_base (start, i)
+				end
 				if
 					not has_absolute_path and then
 					i > start and then

--- a/library/utility/test/unit/uri/ut_test_uri_parser.e
+++ b/library/utility/test/unit/uri/ut_test_uri_parser.e
@@ -60,8 +60,13 @@ feature -- Tests
 			create uri.make ("//www.invalid/abc")
 			check_uri (uri, Void, "www.invalid", "/abc", Void, Void)
 
+			create uri.make ("")
+			assert ("Empty string does not have an absolute path", not uri.has_absolute_path)
+			check_uri (uri, Void, Void, "", Void, Void)
+
 			create uri.make ("/")
 			assert ("/", uri.has_absolute_path)
+			check_uri (uri, Void, Void, "/", Void, Void)
 
 		end
 


### PR DESCRIPTION
UT_URI has a bug where it parses "/" wrongly, returning a path of "//".