### PR TITLE
Use xenial instead of trusty for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 # Use full virtual machine.
-dist: trusty
+dist: xenial
 sudo: required
 
 branches:


### PR DESCRIPTION
Let's use Ubuntu 16.04 instead of 14.04, as that is close to expiry I suppose.