### PR TITLE
Allow redefinition of file in YY_FILE_BUFFER

### DIFF
--- a/library/kernel/src/io/kl_shared_streams.e
+++ b/library/kernel/src/io/kl_shared_streams.e
@@ -14,10 +14,10 @@ class KL_SHARED_STREAMS
 
 feature -- Access
 
-	null_input_stream: KL_STRING_INPUT_STREAM
+	null_input_stream: KI_CHARACTER_INPUT_STREAM
 			-- Null input stream
 		once
-			create Result.make ("")
+			create {KL_STRING_INPUT_STREAM} Result.make ("")
 		ensure
 			null_input_stream_not_void: Result /= Void
 		end


### PR DESCRIPTION
It's impossible to redefine `file' in YY_FILE_BUFFER as in `set_string' file is set to KL_SHARED_STREAMS.null_input_stream. This returns KL_STRING_INPUT_STREAM. As far as I can see there is absolutely no need for this, so I redefined it as returning a KI_CHARACTER_INPUT_STREAM.

That way I can override YY_FILE_BUFFER and redefine both file and null_input_stream to be compatible.