### PR TITLE
Fixed iconv build issue for Mac OS X

### DIFF
--- a/library/free_elks/src/elks/encoding/implementation/unix/Clib/iconv-config
+++ b/library/free_elks/src/elks/encoding/implementation/unix/Clib/iconv-config
@@ -32,12 +32,20 @@ while test $# -gt 0; do
 		elif echo "$ISE_PLATFORM" | grep "windows" >/dev/null 2>&1; then
 			echo -liconv
 # mingw
+		elif [ uname = "Darwin" ]; then
+			echo -liconv
+		else # Potentially sensible default for unknown platform
+			echo -liconv
  		fi
 		;;
 		--include_path)
 		if echo "$ISE_PLATFORM" | grep "bsd" >/dev/null 2>&1; then
 			echo -I/usr/local/include
- 		fi
+ 		elif [ uname = "Darwin" ]; then
+			echo -I/usr/include/
+		else # Potentially sensible default for unknown platform 
+			echo -I/usr/local/include
+		fi
 		;;
 		*)
 		usage 1 1>&2

--- a/tool/gec/doc/platforms.html
+++ b/tool/gec/doc/platforms.html
@@ -92,6 +92,12 @@
       <td>64-bit, little endian, Tru64</td>
       <td></td>
      </tr>
+     <tr>
+      <td>Mac OS X</td>
+      <td>clang 11.0.3</td>
+      <td>64-bit x86</td>
+      <td></td>
+     </tr>
     </tbody>
    </table>
    

--- a/tool/gec/doc/platforms.xml
+++ b/tool/gec/doc/platforms.xml
@@ -103,6 +103,13 @@ has already been used successfully:
 			<entry>64-bit, little endian, Tru64</entry>
 			<entry></entry>
 		</row>
+		<row>
+			<entry>Mac OS X</entry>
+			<entry>clang 11.0.3</entry>
+			<entry>64-bit x86</entry>
+			<entry></entry>
+		</row>
+
 	</tbody>
 	</tgroup>
 </table>


### PR DESCRIPTION
Executing "geant test_debug_ge" results in failed tests under Mac OS X.  This is caused because the iconv library is not correctly linked.

Modified the iconv-config script to return the correct result under Mac OS X.