### PR TITLE
Add OrangeC support

### DIFF
--- a/bin/install.bat
+++ b/bin/install.bat
@@ -148,7 +148,7 @@ goto no_verbose_no_testonly
 
 :usage
 	echo usage: install.bat [-v^|-s][-t] ^<c_compiler^>
-	echo    c_compiler:  msc ^| lcc-win32 ^| lcc-win64 ^| bcc ^| gcc ^| mingw ^| clang ^| cc ^| icc ^| tcc ^| no_c
+	echo    c_compiler:  msc ^| lcc-win32 ^| lcc-win64 ^| bcc ^| gcc ^| mingw ^| clang ^| cc ^| icc ^| tcc ^| occ ^| no_c
 	goto exit
 
 :exit

--- a/tool/gec/bootstrap/bootstrap.bat
+++ b/tool/gec/bootstrap/bootstrap.bat
@@ -80,6 +80,7 @@ if .%CC%. == .clang. goto clang
 if .%CC%. == .cc. goto cc
 if .%CC%. == .icc. goto icc
 if .%CC%. == .tcc. goto tcc
+if .%CC%. == .occ. goto occ
 if .%CC%. == .no_c. goto install
 echo Unknown C compiler: %CC%
 goto exit
@@ -192,6 +193,17 @@ goto exit
 	echo tcc > %GOBO%\tool\gec\config\c\default.cfg
 	goto c_compilation
 
+:occ
+	set CC=occ
+	set LD=occ
+	set CFLAGS=--nologo -O2 -w
+	set LFLAGS=--nologo
+	set LFLAG_OUT=-o 
+	set LLIBS=
+	set OBJ=.o
+	echo occ > %GOBO%\tool\gec\config\c\default.cfg
+	goto c_compilation
+
 :c_compilation
 	if not .%VERBOSE%. == .-s. echo Compiling gec (bootstrap 0)...
 	%CC% %CFLAGS% -c %BOOTSTRAP_DIR%\gec9.c
@@ -245,7 +257,7 @@ goto exit
 
 :usage
 	echo usage: bootstrap.bat [-v^|-s] ^<c_compiler^>
-	echo    c_compiler:  msc ^| lcc-win32 ^| lcc-win64 ^| bcc ^| gcc ^| mingw ^| clang ^| cc ^| icc ^| tcc ^| no_c
+	echo    c_compiler:  msc ^| lcc-win32 ^| lcc-win64 ^| bcc ^| gcc ^| mingw ^| clang ^| cc ^| icc ^| tcc ^| occ ^| no_c
 	goto exit
 
 :exit

--- a/tool/gec/config/c/occ.cfg
+++ b/tool/gec/config/c/occ.cfg
@@ -1,0 +1,33 @@
+-- Command lines
+cc: occ --nologo $cflags $includes  $gc_includes -c $c
+link: occ --nologo $lflags_gui $lflags -o $exe $objs $lflags_threads $libs $gc_libs
+
+-- File extensions
+obj: .o
+exe: .exe
+
+-- Variables
+#ifdef EIF_WORKBENCH
+cflags: -O0 -g
+lflags: -g
+#else
+cflags: -O2 -w
+lflags:
+#endif
+#ifdef EIF_CONSOLE
+lflags_gui: -Wc
+#else
+lflags_gui: -Ww
+#endif
+#ifdef GE_USE_BOEHM_GC
+gc_includes: -I$BOEHM_GC/include -I$BOEHM_GC/include/gc
+gc_libs: $BOEHM_GC/lib/libgc.l
+#else
+gc_includes:
+gc_libs:
+#endif
+#ifdef GE_USE_THREADS
+lflags_threads:
+#else
+lflags_threads:
+#endif


### PR DESCRIPTION
Here is Orange C: https://github.com/LADSoft/OrangeC

Bootstrapping kind of works now, a `gec.exe` is available on bin directory. So it seems boostrap 0 works. But later stages of bootstrap failed for unknown reasons. It said it can't read files on `\tool\gec\runtime\c` even though the files are still there. The GOBO environment variable is correctly set and the bin directory is correctly added to PATH. Also for unknown reasons, it's invoking cl and link. Something in the code forced it to fallback to MSVC. This is when I can't help any further as I don't have any experiences with the internal working of Gobo Eiffel.